### PR TITLE
Fix Pagination

### DIFF
--- a/src/Resources/contao/elements/ContentDownloadarchive.php
+++ b/src/Resources/contao/elements/ContentDownloadarchive.php
@@ -16,6 +16,7 @@
  */
 namespace Swinde\Downloadarchive;
 
+use Contao\Pagination;
 use Patchwork\Utf8;
 
 /**


### PR DESCRIPTION
Behebt eine `Uncaught PHP Exception Symfony\Component\Debug\Exception\ClassNotFoundException: 
"Attempted to load class "Pagination" from namespace "Swinde\Downloadarchive". `

Sobald im Content-Modul eine Anzahl an Elementen pro Seite angegeben wurde, kam es zu einem Frontend-Fehler. Dieser PR behebt das Problem, indem es den richtigen Namespace hinzufügt.

Der Fehler sollte alle Contao 4-Versionen betreffen.